### PR TITLE
MUD-93: fix(config): resolve deprecation warnings for rubocop 1.72+

### DIFF
--- a/rubocop-cops.gemspec
+++ b/rubocop-cops.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name        = 'rubocop-cops'
-  s.version     = '2.1.0'
-  s.date        = '2022-04-13'
+  s.version     = '2.3.0'
+  s.date        = '2026-05-12'
   s.summary     = 'Rubocop config'
   s.description = 'Rubocop config which we gonna add to all ruby projects'
   s.authors     = ['Scentregroup']

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,5 +1,7 @@
-require:
+plugins:
   - rubocop-rails
+
+require:
   - rubocop-rspec
 
 AllCops:
@@ -302,7 +304,7 @@ Style/PercentQLiterals:
     - lower_case_q
     - upper_case_q
 
-Naming/PredicateName:
+Naming/PredicatePrefix:
   NamePrefix:
     - is_
   ForbiddenPrefixes:
@@ -530,7 +532,7 @@ Rails/Date:
     - flexible
 
 Rails/DynamicFindBy:
-  Whitelist:
+  AllowedMethods:
     - find_by_sql
 
 Rails/Exit:


### PR DESCRIPTION
### Description

Fix deprecation warnings emitted by rubocop >= 1.72 when using this shared config:

1. **`require: rubocop-rails` → `plugins: rubocop-rails`** — rubocop 1.72+ migrated extensions to a plugin API. `rubocop-rspec` stays as `require` since it doesn't support plugins yet.
2. **`Naming/PredicateName` → `Naming/PredicatePrefix`** — cop was renamed in recent rubocop versions.
3. **`Rails/DynamicFindBy: Whitelist` → `AllowedMethods`** — parameter was renamed.

Bumps version to 2.3.0.

### Before
```
rubocop-rails extension supports plugin, specify \`plugins: rubocop-rails\` instead of \`require: rubocop-rails\`
Warning: The \`Naming/PredicateName\` cop has been renamed to \`Naming/PredicatePrefix\`.
```

### After
No warnings.