### PR TITLE
MUD-93: fix(deps): add extracted rubocop-rspec gems to silence namespace warnings

### DIFF
--- a/rubocop-cops.gemspec
+++ b/rubocop-cops.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'rubocop-cops'
-  s.version     = '2.3.0'
+  s.version     = '2.4.0'
   s.date        = '2026-05-12'
   s.summary     = 'Rubocop config'
   s.description = 'Rubocop config which we gonna add to all ruby projects'
@@ -11,4 +11,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'rubocop-rails', '~> 2.14'
   s.add_dependency 'rubocop-rspec', '~> 2.9'
+  s.add_dependency 'rubocop-capybara', '~> 2.0'
+  s.add_dependency 'rubocop-factory_bot', '~> 2.0'
+  s.add_dependency 'rubocop-rspec_rails', '~> 2.0'
 end

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -3,6 +3,9 @@ plugins:
 
 require:
   - rubocop-rspec
+  - rubocop-capybara
+  - rubocop-factory_bot
+  - rubocop-rspec_rails
 
 AllCops:
   Exclude:


### PR DESCRIPTION
### JIRA ticket
https://scentregroup.atlassian.net/browse/MUD-93

### Description
`rubocop-rspec` 2.x extracted Capybara, FactoryBot, and Rails cops into separate gems. Without requiring these gems, the old `RSpec/Capybara/*`, `RSpec/FactoryBot/*`, and `RSpec/Rails/*` namespace names emit 20 deprecation warnings.

**Changes:**
- Added `rubocop-capybara`, `rubocop-factory_bot`, `rubocop-rspec_rails` as gem dependencies
- Added them to `require:` in rubocop.yml
- Bumped version to 2.4.0