### PR TITLE
MUD-93: fix(config): use plugins syntax for capybara and factory_bot

### DIFF
--- a/rubocop-cops.gemspec
+++ b/rubocop-cops.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'rubocop-cops'
-  s.version     = '2.4.0'
+  s.version     = '2.4.1'
   s.date        = '2026-05-12'
   s.summary     = 'Rubocop config'
   s.description = 'Rubocop config which we gonna add to all ruby projects'

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,10 +1,10 @@
 plugins:
   - rubocop-rails
+  - rubocop-capybara
+  - rubocop-factory_bot
 
 require:
   - rubocop-rspec
-  - rubocop-capybara
-  - rubocop-factory_bot
   - rubocop-rspec_rails
 
 AllCops:


### PR DESCRIPTION
### JIRA ticket
https://scentregroup.atlassian.net/browse/MUD-93

### Description
Move `rubocop-capybara` and `rubocop-factory_bot` from `require:` to `plugins:` to silence warnings. `rubocop-rspec` and `rubocop-rspec_rails` don't support `plugins:` yet so stay as `require:`.