### PR TITLE
MUD-93: fix(deps): upgrade rubocop-rspec to v3 and use plugins syntax

### DIFF
--- a/rubocop-cops.gemspec
+++ b/rubocop-cops.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name        = 'rubocop-cops'
-  s.version     = '2.4.1'
-  s.date        = '2026-05-12'
+  s.version     = '2.5.0'
+  s.date        = '2026-05-13'
   s.summary     = 'Rubocop config'
   s.description = 'Rubocop config which we gonna add to all ruby projects'
   s.authors     = ['Scentregroup']
@@ -10,8 +10,8 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
 
   s.add_dependency 'rubocop-rails', '~> 2.14'
-  s.add_dependency 'rubocop-rspec', '~> 2.9'
+  s.add_dependency 'rubocop-rspec', '~> 3.0'
   s.add_dependency 'rubocop-capybara', '~> 2.0'
   s.add_dependency 'rubocop-factory_bot', '~> 2.0'
-  s.add_dependency 'rubocop-rspec_rails', '~> 2.0'
+  s.add_dependency 'rubocop-rspec_rails', '~> 2.30'
 end

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -2,8 +2,6 @@ plugins:
   - rubocop-rails
   - rubocop-capybara
   - rubocop-factory_bot
-
-require:
   - rubocop-rspec
   - rubocop-rspec_rails
 


### PR DESCRIPTION
### JIRA ticket

https://scentregroup.atlassian.net/browse/MUD-93

### Description

Upgrades rubocop-rspec to v3 and switches from deprecated `require` to `plugins` syntax, fixing compatibility with rubocop >= 1.86.

#### Problem

`rubocop-rspec_rails 2.29.1` calls `inject_defaults!` with a directory path, which rubocop 1.86+ no longer supports. Upgrading `rubocop-rspec_rails` to >= 2.30 requires `rubocop-rspec ~> 3`, which the current `~> 2.9` constraint blocks.

#### Changes

| File | Change |
|---|---|
| `rubocop-cops.gemspec` | `rubocop-rspec` `~> 2.9` → `~> 3.0`, `rubocop-rspec_rails` `~> 2.0` → `~> 2.30`, version bump to 2.5.0 |
| `rubocop.yml` | Move `rubocop-rspec` and `rubocop-rspec_rails` from `require` to `plugins` (3.x API) |

No RSpec-specific cop configurations exist in the shared config, so the v3 upgrade is a drop-in replacement.